### PR TITLE
Constrain minimum train set length for SU jobs

### DIFF
--- a/ProceduralJobGenerators.cs
+++ b/ProceduralJobGenerators.cs
@@ -99,7 +99,7 @@ namespace DVOwnership
 			}
 			var warehouseMachine = Utilities.GetRandomFrom(rng, warehouseMachinesThatSupportCargoTypes);
 
-			var randomSortingOfCarsOnTracks = Utilities.GetRandomSortingOfCarsOnTracks(rng, destinationController.logicStation.yard.StorageTracks, carsForJob, generationRuleset.maxShuntingStorageTracks);
+			var randomSortingOfCarsOnTracks = Utilities.GetRandomSortingOfCarsOnTracks(rng, destinationController.logicStation.yard.StorageTracks, carsForJob, generationRuleset.maxShuntingStorageTracks, generationRuleset.minCarsPerJob);
 			if (randomSortingOfCarsOnTracks == null)
 			{
 				DVOwnership.LogDebug(() => $"Station[{destinationController.logicStation.ID}] couldn't assign cars to storage tracks.");

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -15,18 +15,20 @@ namespace DVOwnership
 			return enumerable.ElementAt(index);
 		}
 
-		public static List<CarsPerTrack> GetRandomSortingOfCarsOnTracks(System.Random rng, List<Track> tracks, List<Car> allCarsForJobChain, int maxNumberOfStorageTracks)
+		public static List<CarsPerTrack> GetRandomSortingOfCarsOnTracks(System.Random rng, List<Track> tracks, List<Car> allCarsForJobChain, int maxNumberOfStorageTracks, int minNumberOfCarsPerTrack)
 		{
 			if (tracks == null || tracks.Count == 0) { return null; }
 
 			int numCars = allCarsForJobChain.Count;
+			int minCarsPerTrack = Math.Min(numCars, Math.Max(1, minNumberOfCarsPerTrack));
+			int maxTracks = numCars / minCarsPerTrack;
 			int numTracks = Mathf.Min(new int[]
 			{
 				rng.Next(1, maxNumberOfStorageTracks + 1),
 				tracks.Count,
-				numCars
+				maxTracks
 			});
-			int averageNumCarsPerTrack = Mathf.FloorToInt((float)numCars / (float)numTracks);
+			int avgCarsPerTrack = numCars / numTracks;
 
 			List<int> numCarsPerTracks = new List<int>();
 			int numCarsAccountedFor = 0;
@@ -39,7 +41,7 @@ namespace DVOwnership
 				}
 				else
 				{
-					numCarsForCurrentTrack = rng.Next(1, averageNumCarsPerTrack + 1);
+					numCarsForCurrentTrack = rng.Next(minCarsPerTrack, avgCarsPerTrack + 1);
 				}
 				if (numCarsForCurrentTrack < 1)
 				{
@@ -48,7 +50,7 @@ namespace DVOwnership
 				numCarsPerTracks.Add(numCarsForCurrentTrack);
 				numCarsAccountedFor += numCarsForCurrentTrack;
 			}
-			numCarsPerTracks.Sort((a, b) => b - a); // reverse sort
+			numCarsPerTracks.Sort((a, b) => b - a); // sort in descending order
 
 			YardTracksOrganizer yto = SingletonBehaviour<YardTracksOrganizer>.Instance;
 			List<CarsPerTrack> carsPerTracks = new List<CarsPerTrack>();


### PR DESCRIPTION
Breaking the train set apart during a SU job into train sets that are shorter than the minimum length required for jobs results in unnecessary work that must simply be undone by the next SL job. This feels pointless (because it is), and that's *no fun*.

We can prevent this unnecessary work by constraining the minimum number of cars that a SU job may place on any one track to the minimum number of cars required for a job.