### PR TITLE
Generate new SL jobs after completing SU jobs

### DIFF
--- a/Patches/JobChainControllerWithEmptyHaulGeneration_Patches.cs
+++ b/Patches/JobChainControllerWithEmptyHaulGeneration_Patches.cs
@@ -1,6 +1,7 @@
 ﻿using DV.Logic.Job;
 using Harmony12;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection.Emit;
 
 namespace DVOwnership.Patches
@@ -47,6 +48,10 @@ namespace DVOwnership.Patches
 			else if (jobType == JobType.ShuntingUnload)
 			{
 				ProceduralJobGenerators.SetDestination(__instance, null);
+				if (!StationProceduralJobsController_Patches.StartJobGenerationCoroutine(destinationController, __instance.trainCarsForJobChain.Select(trainCar => trainCar.logicCar)))
+				{
+					DVOwnership.LogWarning($"Couldn't start job generation coroutine for ${destinationController.logicStation.ID}.\nGeneration of a new shunting load job for cars from ${lastJobInChain.ID} hasn't been attempted.");
+				}
 			}
 		}
 

--- a/Patches/StationProceduralJobsController_Patches.cs
+++ b/Patches/StationProceduralJobsController_Patches.cs
@@ -1,11 +1,13 @@
-﻿using Harmony12;
-using System;
+﻿using DV.Logic.Job;
+using Harmony12;
+using System.Collections.Generic;
 
 namespace DVOwnership.Patches
 {
 	public class StationProceduralJobsController_Patches
 	{
 		private static bool isSetup = false;
+		private static Dictionary<StationController, StationProceduralJobsController> instances = new Dictionary<StationController, StationProceduralJobsController>();
 
 		public static void Setup()
 		{
@@ -18,25 +20,57 @@ namespace DVOwnership.Patches
 			DVOwnership.Log("Setting up StationProceduralJobsController patches.");
 
 			isSetup = true;
+			var StationProceduralJobsController_Awake = AccessTools.Method(typeof(StationProceduralJobsController), "Awake");
+			var StationProceduralJobsController_Awake_Postfix = AccessTools.Method(typeof(StationProceduralJobsController_Patches), nameof(Awake_Postfix));
+			DVOwnership.Patch(StationProceduralJobsController_Awake, postfix: new HarmonyMethod(StationProceduralJobsController_Awake_Postfix));
 			var StationProceduralJobsController_TryToGenerateJobs = AccessTools.Method(typeof(StationProceduralJobsController), nameof(StationProceduralJobsController.TryToGenerateJobs));
 			var StationProceduralJobsController_TryToGenerateJobs_Prefix = AccessTools.Method(typeof(StationProceduralJobsController_Patches), nameof(TryToGenerateJobs_Prefix));
 			DVOwnership.Patch(StationProceduralJobsController_TryToGenerateJobs, prefix: new HarmonyMethod(StationProceduralJobsController_TryToGenerateJobs_Prefix));
+		}
+
+		static void Awake_Postfix(StationProceduralJobsController __instance)
+		{
+			instances.Add(__instance.stationController, __instance);
 		}
 
 		static bool TryToGenerateJobs_Prefix(StationProceduralJobsController __instance, StationController ___stationController)
 		{
 			DVOwnership.Log($"Generating jobs for equipment at {__instance.stationController.logicStation.ID} station.");
 
-			__instance.StopJobGeneration();
-			ProceduralJobsController jobsController = ProceduralJobsController.ForStation(___stationController);
-
-			var generationCoroField = AccessTools.Field(typeof(StationProceduralJobsController), "generationCoro");
-			Action onComplete = () => generationCoroField.SetValue(__instance, null);
-			var generationCoro = __instance.StartCoroutine(jobsController.GenerateJobsCoro(onComplete));
-			generationCoroField.SetValue(__instance, generationCoro);
+			StartJobGenerationCoroutine(__instance, ___stationController);
 
 			DVOwnership.Log("Skipping default job generation.");
 			return false;
+		}
+
+		public static StationProceduralJobsController JobsControllerForStation(StationController stationController)
+		{
+			if (instances.TryGetValue(stationController, out StationProceduralJobsController jobsController))
+			{
+				return jobsController;
+			}
+
+			return null;
+		}
+
+		public static bool StartJobGenerationCoroutine(StationController stationController, IEnumerable<Car> carsToUse)
+		{
+			var jobsController = JobsControllerForStation(stationController);
+			if (jobsController == null) { return false; }
+
+			StartJobGenerationCoroutine(jobsController, stationController, carsToUse);
+			return true;
+		}
+
+		private static void StartJobGenerationCoroutine(StationProceduralJobsController instance, StationController stationController, IEnumerable<Car> carsToUse = null)
+		{
+			instance.StopJobGeneration();
+			ProceduralJobsController jobsController = ProceduralJobsController.ForStation(stationController);
+
+			var generationCoroField = AccessTools.Field(typeof(StationProceduralJobsController), "generationCoro");
+			void onComplete() => generationCoroField.SetValue(instance, null);
+			var generationCoro = instance.StartCoroutine(jobsController.GenerateJobsCoro(onComplete, carsToUse));
+			generationCoroField.SetValue(instance, generationCoro);
 		}
 	}
 }


### PR DESCRIPTION
Having to vacate the station to trigger generation of new jobs for train cars that have completed their job chain is bothersome. This change causes new shunting load jobs—and thus new job chains—to be created immediately, assuming the train cars support carrying a cargo type that the station loads.