### PR TITLE
Show floaty messages for critical failures

### DIFF
--- a/DVOwnership.cs
+++ b/DVOwnership.cs
@@ -126,23 +126,26 @@ namespace DVOwnership
 
 		public static void OnCriticalFailure(Exception exception, string action)
 		{
-			// TODO: show floaty message (and offer to open log folder?) before quitting game
 			Debug.Log(exception);
+			string message = $"DVOwnership encountered an unrecoverable error while {action}";
 #if DEBUG
+			message += ".";
 #else
 			modEntry.Enabled = false;
-			modEntry.Logger.Critical("Deactivating mod DVOwnership due to unrecoverable failure!");
+			message += " and has been deactivated.";
 #endif
-			modEntry.Logger.Critical($"This happened while {action}.");
-			modEntry.Logger.Critical($"You can reactivate DVOwnership by restarting the game, but this failure type likely indicates an incompatibility between the mod and a recent game update. Please search the mod's Github issue tracker for a relevant report. If none is found, please open one and include this log file.");
-			Application.Quit();
+			modEntry.Logger.Critical(message);
+			modEntry.Logger.Critical($"You can reactivate DVOwnership from the UMM Settings menu, but this failure type likely indicates an incompatibility between the mod and a recent game update. Please search the mod's Github issue tracker for a relevant report. If none is found, please open one and include this log file.");
+			MessageBox.ShowMessage(message + " View the Player.log file for more details.\n\nThe game will exit after this message is closed.", true);
+			MessageBox.OnClosed(() => { Application.Quit(); });
 		}
 
 		private static void NeedsUpdate()
 		{
-			// TODO: show floaty message before quitting game
-			modEntry.Logger.Critical($"There is a new version of DVOwnership available. Please install it to continue using the mod.\nInstalled: {modEntry.Version}\nLatest: {modEntry.NewestVersion}");
-			Application.Quit();
+			var message = $"There is a new version of DVOwnership available. Please install it to continue using the mod.\nInstalled: {modEntry.Version}\nLatest: {modEntry.NewestVersion}";
+			modEntry.Logger.Critical(message);
+			MessageBox.ShowMessage(message + "\n\nThe game will exit after this message is closed.", true);
+			MessageBox.OnClosed(() => { Application.Quit(); });
 		}
 	}
 }

--- a/MessageBox.cs
+++ b/MessageBox.cs
@@ -1,0 +1,73 @@
+#nullable enable
+using Harmony12;
+using System;
+using System.Collections;
+
+// Copyright 2020 Miles Spielberg
+
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject
+// to the following conditions:
+
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+// ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+namespace DVOwnership
+{
+	public static class MessageBox
+	{
+		public static void ShowMessage(string message, bool pauseGame)
+		{
+			if (WorldStreamingInit.IsLoaded)
+			{
+				StartCoro(message, pauseGame);
+			}
+			else
+			{
+				WorldStreamingInit.LoadingFinished += () => StartCoro(message, pauseGame);
+			}
+		}
+
+		private static void StartCoro(string message, bool pauseGame)
+		{
+			SingletonBehaviour<CanvasSpawner>.Instance.StartCoroutine(Coro(message, pauseGame));
+		}
+
+		private static IEnumerator Coro(string message, bool pauseGame)
+		{
+			while (!SingletonBehaviour<CanvasSpawner>.Instance.MenuLoaded)
+				yield return null;
+			while (DV.AppUtil.IsPaused)
+				yield return null;
+			while (SingletonBehaviour<CanvasSpawner>.Instance.IsOpen)
+				yield return null;
+			yield return WaitFor.Seconds(1f);
+			MenuScreen? menuScreen = SingletonBehaviour<CanvasSpawner>.Instance.CanvasGO.transform.Find("TutorialPrompt")?.GetComponent<MenuScreen>();
+			TutorialPrompt? tutorialPrompt = menuScreen?.GetComponentInChildren<TutorialPrompt>(includeInactive: true);
+			if (menuScreen != null && tutorialPrompt != null)
+			{
+				tutorialPrompt.SetText(message);
+				SingletonBehaviour<CanvasSpawner>.Instance.Open(menuScreen, pauseGame);
+			}
+		}
+
+		public static void OnClosed(Action action)
+		{
+			var canvasSpawner = SingletonBehaviour<CanvasSpawner>.Instance;
+			var screenSwitcher = AccessTools.Field(typeof(CanvasSpawner), "screenSwitcher").GetValue(canvasSpawner) as MenuScreenSwitcher;
+			if (screenSwitcher != null) { screenSwitcher.MenuClosed += action; }
+		}
+	}
+}


### PR DESCRIPTION
This change introduces showing in-game messages to the player when a critical failure has occurred and the game will be closed. This is an improvement over only logging the failure to the log file as the player will have more context to understand why the game has quit, which could otherwise appear as if it were a crash.

Based on and code from [dv-handbrake](https://github.com/mspielberg/dv-handbrake/blob/03a5d3ef1206b297cbf8dc9dc4739852e5ec7acf/HandBrake.cs#L79-L115).